### PR TITLE
OC-406 Fixes

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,9 @@
 # Used by "mix format"
+
+locals_without_parens = [given: :*, act: :*, check: :*]
+
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  locals_without_parens: locals_without_parens,
+  export: [locals_without_parens: locals_without_parens]
 ]

--- a/lib/scenario.ex
+++ b/lib/scenario.ex
@@ -96,6 +96,7 @@ defmodule Behave.Scenario do
 
     quote do
       def unquote(name)(scenario, _) do
+        var!(data) = scenario.data
         var!(results) = scenario.results
         unquote(block)
         scenario

--- a/lib/scenario.ex
+++ b/lib/scenario.ex
@@ -5,9 +5,11 @@ defmodule Behave.Scenario do
     end
   end
 
-  defstruct steps: [], data: [], results: []
+  defstruct steps: [], data: %{}, results: %{}
 
-  @spec new :: %Behave.Scenario{data: [], results: [], steps: []}
+  @type t :: %__MODULE__{}
+
+  @spec new :: t
   def new, do: %__MODULE__{}
 
   defmacro given(name, do: block) do
@@ -52,8 +54,8 @@ defmodule Behave.Scenario do
     name = Behave.string_to_function_name("act_#{name}")
 
     quote do
-      def unquote(name)(scenario = %Behave.Scenario{data: d}, _) do
-        var!(data) = Map.new(d)
+      def unquote(name)(scenario, _) do
+        var!(data) = scenario.data
         result = unquote(block)
         Behave.Scenario.__act__(scenario, result)
       end
@@ -62,9 +64,10 @@ defmodule Behave.Scenario do
 
   defmacro act(name, args, do: block) do
     name = Behave.string_to_function_name("act_#{name}")
+
     quote do
-      def unquote(name)(scenario = %Behave.Scenario{data: d}, unquote(args)) do
-        var!(data) = Map.new(d)
+      def unquote(name)(scenario, unquote(args)) do
+        var!(data) = scenario.data
         result = unquote(block)
         Behave.Scenario.__act__(scenario, result)
       end
@@ -92,8 +95,8 @@ defmodule Behave.Scenario do
     name = Behave.string_to_function_name("check_#{name}")
 
     quote do
-      def unquote(name)(scenario = %Behave.Scenario{results: r}, _) do
-        var!(results) = Map.new(r)
+      def unquote(name)(scenario, _) do
+        var!(results) = scenario.results
         unquote(block)
         scenario
       end
@@ -102,10 +105,11 @@ defmodule Behave.Scenario do
 
   defmacro check(name, args, do: block) do
     name = Behave.string_to_function_name("check_#{name}")
+
     quote do
-      def unquote(name)(scenario = %Behave.Scenario{data: d, results: r}, unquote(args)) do
-        var!(data) = Map.new(d)
-        var!(results) = Map.new(r)
+      def unquote(name)(scenario, unquote(args)) do
+        var!(data) = scenario.data
+        var!(results) = scenario.results
         unquote(block)
         scenario
       end

--- a/lib/scenario.ex
+++ b/lib/scenario.ex
@@ -56,6 +56,7 @@ defmodule Behave.Scenario do
     quote do
       def unquote(name)(scenario, _) do
         var!(data) = scenario.data
+        _ = var!(data)
         result = unquote(block)
         Behave.Scenario.__act__(scenario, result)
       end
@@ -68,6 +69,7 @@ defmodule Behave.Scenario do
     quote do
       def unquote(name)(scenario, unquote(args)) do
         var!(data) = scenario.data
+        _ = var!(data)
         result = unquote(block)
         Behave.Scenario.__act__(scenario, result)
       end
@@ -98,6 +100,8 @@ defmodule Behave.Scenario do
       def unquote(name)(scenario, _) do
         var!(data) = scenario.data
         var!(results) = scenario.results
+        _ = var!(data)
+        _ = var!(results)
         unquote(block)
         scenario
       end
@@ -111,6 +115,8 @@ defmodule Behave.Scenario do
       def unquote(name)(scenario, unquote(args)) do
         var!(data) = scenario.data
         var!(results) = scenario.results
+        _ = var!(data)
+        _ = var!(results)
         unquote(block)
         scenario
       end

--- a/test/behave_explicit_test.exs
+++ b/test/behave_explicit_test.exs
@@ -4,6 +4,7 @@ defmodule BehaveExplicitTest do
   use ExUnit.Case
 
   import TestSteps
+
   test "make coffee explicitly" do
     Scenario.new()
     |> Behave.__given__(&given_coffee_machine/2)

--- a/test/support/test_steps.ex
+++ b/test/support/test_steps.ex
@@ -1,24 +1,24 @@
 defmodule TestSteps do
-    use Behave.Scenario
-    import ExUnit.Assertions
+  use Behave.Scenario
+  import ExUnit.Assertions
 
-    given "coffee machine" do
-      {:coffee_machine, CoffeeMachine.new()}
-    end
+  given "coffee machine" do
+    {:coffee_machine, CoffeeMachine.new()}
+  end
 
-    given "it has water", amount: amount do
-      {:coffee_machine, &CoffeeMachine.add_water(&1, amount)}
-    end
+  given "it has water", amount: amount do
+    {:coffee_machine, &CoffeeMachine.add_water(&1, amount)}
+  end
 
-    given "it has coffee", cultivar: cultivar do
-      {:coffee_machine, &CoffeeMachine.add_coffee(&1, cultivar)}
-    end
+  given "it has coffee", cultivar: cultivar do
+    {:coffee_machine, &CoffeeMachine.add_coffee(&1, cultivar)}
+  end
 
-    act "i press the button" do
-      {:coffee, CoffeeMachine.brew(data.coffee_machine)}
-    end
+  act "i press the button" do
+    {:coffee, CoffeeMachine.brew(data.coffee_machine)}
+  end
 
-    check "it makes coffee" do
-      assert results.coffee != :disappointment
-    end
+  check "it makes coffee" do
+    assert results.coffee != :disappointment
+  end
 end


### PR DESCRIPTION
Includes fixes for: 
https://clarkteam.atlassian.net/browse/OC-408 
https://clarkteam.atlassian.net/browse/OC-409

Adds missing formatter export:
https://clarkteam.atlassian.net/browse/OC-410

Later we can discuss if we are happy with injection of `"data"` and `"results"` macro variables in `act` and `check` blocks and if not we may find alternative macros or change design in general. 